### PR TITLE
Update citation and adjust bootstrapping population size

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: MotifPeeker
 Title: Benchmarking Epigenomic Profiling Methods Using Motif Enrichment
-Version: 1.3.1
+Version: 1.3.2
 Authors@R: c( 
     person(given = "Hiranyamaya",
            family = "Dash",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 * Bound maximum bootstrapping population size.
 
+## Misclaneous
+* Update CITATION: MotifPeeker is now published on Bioinformatics Advances!
+
 # MotifPeeker 1.3.1
 
 ## Section Rework

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# MotifPeeker 1.3.2
+
+## Bug Fixes
+
+* Bound maximum bootstrapping population size.
+
 # MotifPeeker 1.3.1
 
 ## Section Rework

--- a/R/bootstrap_distances.R
+++ b/R/bootstrap_distances.R
@@ -67,7 +67,7 @@ bootstrap_distances <- function(peaks,
         messager("Setting samples_n to number of peaks for bootstrapping",
                  "motif-summit distances:", length(peaks),
                 v = verbose)
-        samples_n <- max(round(length(peaks) * 0.7), 10)
+        samples_n <- min(max(round(length(peaks) * 0.7), 10), length(peaks))
     }
     if (is.null(samples_len)) {
         messager("Setting samples_len to 1000 for bootstrapping",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ style="height: 300px !important;" />
 history](https://bioconductor.org/shields/years-in-bioc/MotifPeeker.svg)](https://bioconductor.org/packages/devel/bioc/html/MotifPeeker.html#since)
 [![License: GPL (\>=
 3)](https://img.shields.io/badge/license-GPL%20(%3E=%203)-blue.svg)](https://cran.r-project.org/web/licenses/GPL%20(%3E=%203))
-[![](https://img.shields.io/badge/devel%20version-1.3.0-black.svg)](https://github.com/neurogenomics/MotifPeeker)
+[![](https://img.shields.io/badge/devel%20version-1.3.1-black.svg)](https://github.com/neurogenomics/MotifPeeker)
 [![](https://img.shields.io/github/languages/code-size/neurogenomics/MotifPeeker.svg)](https://github.com/neurogenomics/MotifPeeker)
 [![](https://img.shields.io/github/last-commit/neurogenomics/MotifPeeker.svg)](https://github.com/neurogenomics/MotifPeeker/commits/master)
 <br> [![R build
@@ -20,7 +20,7 @@ status](https://github.com/neurogenomics/MotifPeeker/workflows/rworkflows/badge.
 
 **Authors:** ***Hiranyamaya (Hiru) Dash, Thomas Roberts, Maria Weinert,
 Nathan Skene***  
-**Updated:** ***Nov-20-2025***
+**Updated:** ***Feb-19-2026***
 
 ## Introduction
 
@@ -369,13 +369,13 @@ Imperial College London
 utils::sessionInfo()
 ```
 
-    ## R Under development (unstable) (2025-10-27 r88972)
-    ## Platform: aarch64-apple-darwin20
-    ## Running under: macOS Tahoe 26.1
+    ## R Under development (unstable) (2026-02-16 r89426)
+    ## Platform: aarch64-apple-darwin23
+    ## Running under: macOS Tahoe 26.3
     ## 
     ## Matrix products: default
-    ## BLAS:   /Library/Frameworks/R.framework/Versions/4.6-arm64/Resources/lib/libRblas.0.dylib 
-    ## LAPACK: /Library/Frameworks/R.framework/Versions/4.6-arm64/Resources/lib/libRlapack.dylib;  LAPACK version 3.12.1
+    ## BLAS:   /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib 
+    ## LAPACK: /Library/Frameworks/R.framework/Versions/4.6/Resources/lib/libRlapack.dylib;  LAPACK version 3.12.1
     ## 
     ## locale:
     ## [1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8
@@ -387,20 +387,21 @@ utils::sessionInfo()
     ## [1] stats     graphics  grDevices utils     datasets  methods   base     
     ## 
     ## loaded via a namespace (and not attached):
-    ##  [1] gtable_0.3.6        jsonlite_2.0.0      renv_1.1.5         
-    ##  [4] dplyr_1.1.4         compiler_4.6.0      BiocManager_1.30.26
+    ##  [1] gtable_0.3.6        jsonlite_2.0.0      renv_1.1.7         
+    ##  [4] dplyr_1.2.0         compiler_4.6.0      BiocManager_1.30.27
     ##  [7] tidyselect_1.2.1    rvcheck_0.2.1       scales_1.4.0       
-    ## [10] yaml_2.3.10         fastmap_1.2.0       here_1.0.2         
-    ## [13] ggplot2_4.0.0       R6_2.6.1            generics_0.1.4     
-    ## [16] knitr_1.50          yulab.utils_0.2.1   tibble_3.3.0       
+    ## [10] yaml_2.3.12         fastmap_1.2.0       here_1.0.2         
+    ## [13] ggplot2_4.0.2       R6_2.6.1            generics_0.1.4     
+    ## [16] knitr_1.51          yulab.utils_0.2.4   tibble_3.3.1       
     ## [19] desc_1.4.3          dlstats_0.1.7       rprojroot_2.1.1    
-    ## [22] pillar_1.11.1       RColorBrewer_1.1-3  rlang_1.1.6        
-    ## [25] badger_0.2.5        xfun_0.54           fs_1.6.6           
-    ## [28] S7_0.2.0            cli_3.6.5           magrittr_2.0.4     
-    ## [31] rworkflows_1.0.6    digest_0.6.37       grid_4.6.0         
-    ## [34] rstudioapi_0.17.1   rappdirs_0.3.3      lifecycle_1.0.4    
-    ## [37] vctrs_0.6.5         evaluate_1.0.5      glue_1.8.0         
-    ## [40] data.table_1.17.8   farver_2.1.2        rmarkdown_2.30     
-    ## [43] tools_4.6.0         pkgconfig_2.0.3     htmltools_0.5.8.1
+    ## [22] pillar_1.11.1       RColorBrewer_1.1-3  rlang_1.1.7        
+    ## [25] badger_0.2.5        xfun_0.56           fs_1.6.6           
+    ## [28] S7_0.2.1            otel_0.2.0          cli_3.6.5          
+    ## [31] magrittr_2.0.4      rworkflows_1.0.8    digest_0.6.39      
+    ## [34] grid_4.6.0          rstudioapi_0.18.0   rappdirs_0.3.4     
+    ## [37] lifecycle_1.0.5     vctrs_0.7.1         data.table_1.18.2.1
+    ## [40] evaluate_1.0.5      glue_1.8.0          farver_2.1.2       
+    ## [43] rmarkdown_2.30      tools_4.6.0         pkgconfig_2.0.3    
+    ## [46] htmltools_0.5.9
 
 </details>

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,21 +1,23 @@
-citHeader("To cite MotifPeeker, please use:")
-
-citEntry(
-  entry    = "Article",
-  title    = "MotifPeeker: R package for benchmarking epigenomic profiling methods using motif enrichment as a key metric",
-  author   = personList(as.person("Hiranyamaya Dash"),
-                        as.person("Thomas Roberts"),
-                        as.person("Maria Weinert"),
-                        as.person("Nathan G. Skene")),
-  journal  = "bioRxiv",
-  year     = "2025",
-  volume   = NULL,
-  number   = NULL,
-  pages    = NULL,
-  url      = "https://doi.org/10.1101/2025.03.31.645756",
+bibentry(
+  bibtype = "Article",
+  title = "MotifPeeker: Benchmarking epigenomic profiling methods using motifs",
+  author = c(
+    person("Hiranyamaya", "Dash"),
+    person("Thomas", "Roberts"),
+    person("Maria", "Weinert"),
+    person("Nathan", "Skene")
+  ),
+  journal = "Bioinformatics Advances",
+  year = "2026",
+  month = "Feb",
+  eid = "vbag023",
+  issn = "2635-0041",
+  doi = "10.1093/bioadv/vbag023",
+  url = "https://doi.org/10.1093/bioadv/vbag023",
   textVersion = paste(
-  "MotifPeeker: R package for benchmarking epigenomic profiling methods using motif enrichment as a key metric (2025) 
-  Hiranyamaya Dash, Thomas Roberts, Maria Weinert, Nathan Skene,
-  bioRxiv, 2025.03.31.645756; doi: https://doi.org/10.1101/2025.03.31.645756"
+    "Dash H, Roberts T, Weinert M, Skene N (2026).",
+    "MotifPeeker: Benchmarking epigenomic profiling methods using motifs.",
+    "Bioinformatics Advances, vbag023.",
+    "doi:10.1093/bioadv/vbag023"
   )
 )


### PR DESCRIPTION
Incorporates two commits from the `peak-score` branch into `master`.

## Changes

- **`R/bootstrap_distances.R`**: `samples_n` could exceed `length(peaks)`, causing sampling errors. Bounded with `min()`:
  ```r
  # Before
  samples_n <- max(round(length(peaks) * 0.7), 10)
  # After
  samples_n <- min(max(round(length(peaks) * 0.7), 10), length(peaks))
  ```

- **`inst/CITATION`**: Updated from bioRxiv preprint → published article in *Bioinformatics Advances* (`doi:10.1093/bioadv/vbag023`). Migrated from deprecated `citEntry`/`personList`/`as.person` to modern `bibentry`/`person` format.

- **`DESCRIPTION` / `NEWS.md`**: Version bump `1.3.1 → 1.3.2` with release notes.

- **`README.md`**: Version badge and session info updated to match.